### PR TITLE
feat(validation): fetch the builder disallow list from a url and hot-reload it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9216,6 +9216,7 @@ dependencies = [
  "futures",
  "jsonrpsee-core",
  "rand 0.9.4",
+ "reqwest 0.13.2",
  "reth-chainspec",
  "reth-db",
  "reth-e2e-test-utils",

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -52,6 +52,9 @@ revm = { workspace = true, features = ["secp256k1", "blst", "c-kzg", "memory_lim
 
 # misc
 eyre.workspace = true
+reqwest.workspace = true
+serde_json.workspace = true
+alloy-primitives.workspace = true
 
 [dev-dependencies]
 reth-db.workspace = true

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -50,13 +50,46 @@ use reth_rpc_eth_api::{
 };
 use reth_rpc_eth_types::{error::FromEvmError, EthApiError};
 use reth_rpc_server_types::RethRpcModule;
-use reth_tracing::tracing::{debug, info};
+use reth_tracing::tracing::{debug, info, warn};
 use reth_transaction_pool::{
     blobstore::DiskFileBlobStore, EthTransactionPool, PoolPooledTx, PoolTransaction,
     TransactionPool, TransactionValidationTaskExecutor,
 };
 use revm::context::TxEnv;
-use std::{marker::PhantomData, sync::Arc, time::SystemTime};
+use std::{
+    marker::PhantomData,
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+use alloy_primitives::map::AddressSet;
+
+/// How often a running node re-fetches the builder disallow list from its url.
+const DISALLOW_REFRESH_INTERVAL: Duration = Duration::from_secs(300);
+
+/// Fetches and parses the disallow list (json array of address strings) from `url`.
+async fn fetch_disallow(client: &reqwest::Client, url: &str) -> eyre::Result<AddressSet> {
+    let body = client.get(url).send().await?.error_for_status()?.text().await?;
+    Ok(serde_json::from_str(&body)?)
+}
+
+/// Fetches the disallow list at startup, retrying a few times, then exits the process if it
+/// cannot be loaded — a sim node must never run without its sanctions list.
+async fn fetch_disallow_or_exit(url: &str) -> AddressSet {
+    let client = reqwest::Client::new();
+    for attempt in 1..=5u32 {
+        match fetch_disallow(&client, url).await {
+            Ok(disallow) => {
+                info!(target: "reth::cli", count = disallow.len(), %url, "loaded builder disallow list");
+                return disallow;
+            }
+            Err(error) => {
+                warn!(target: "reth::cli", attempt, %url, %error, "failed to fetch builder disallow list at startup");
+                tokio::time::sleep(Duration::from_secs(2)).await;
+            }
+        }
+    }
+    panic!("could not fetch builder disallow list from {url} after 5 attempts; refusing to start");
+}
 
 /// Type configuration for a regular Ethereum node.
 #[derive(Debug, Default, Clone, Copy)]
@@ -322,14 +355,41 @@ where
         self,
         ctx: reth_node_api::AddOnsContext<'_, N>,
     ) -> eyre::Result<Self::Handle> {
+        let disallow_url = ctx.config.rpc.builder_disallow_url.clone();
+
+        let mut flashbots_config = ctx.config.rpc.flashbots_config();
+        if let Some(url) = &disallow_url {
+            flashbots_config.disallow = fetch_disallow_or_exit(url).await;
+        }
+
         let validation_api = ValidationApi::<_, _, <N::Types as NodeTypes>::Payload>::new(
             ctx.node.provider().clone(),
             Arc::new(ctx.node.consensus().clone()),
             ctx.node.evm_config().clone(),
-            ctx.config.rpc.flashbots_config(),
+            flashbots_config,
             ctx.node.task_executor().clone(),
             Arc::new(EthereumEngineValidator::new(ctx.config.chain.clone())),
         );
+
+        if let Some(url) = disallow_url {
+            let validation_api = validation_api.clone();
+            let client = reqwest::Client::new();
+            ctx.node.task_executor().spawn_task(async move {
+                let mut ticker = tokio::time::interval(DISALLOW_REFRESH_INTERVAL);
+                ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                ticker.tick().await;
+                loop {
+                    ticker.tick().await;
+                    match fetch_disallow(&client, &url).await {
+                        Ok(disallow) => validation_api.update_disallow(disallow),
+                        Err(error) => warn!(
+                            target: "reth::cli", %url, %error,
+                            "failed to refresh builder disallow list, keeping last-good"
+                        ),
+                    }
+                }
+            });
+        }
 
         let eth_config =
             EthConfigHandler::new(ctx.node.provider().clone(), ctx.node.evm_config().clone());

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -4,7 +4,6 @@ use crate::args::{
     types::{MaxU32, ZeroAsNoneU64},
     GasPriceOracleArgs, RpcStateCacheArgs,
 };
-use alloy_primitives::map::AddressSet;
 use alloy_rpc_types_engine::JwtSecret;
 use clap::{
     builder::{PossibleValue, RangedU64ValueParser, Resettable, TypedValueParser},
@@ -88,7 +87,7 @@ pub struct DefaultRpcServerArgs {
     rpc_proof_permits: usize,
     rpc_pending_block: PendingBlockKind,
     rpc_forwarder: Option<Url>,
-    builder_disallow: Option<AddressSet>,
+    builder_disallow_url: Option<String>,
     rpc_state_cache: RpcStateCacheArgs,
     gas_price_oracle: GasPriceOracleArgs,
     rpc_send_raw_transaction_sync_timeout: Duration,
@@ -333,9 +332,9 @@ impl DefaultRpcServerArgs {
         self
     }
 
-    /// Set the default builder disallow addresses
-    pub fn with_builder_disallow(mut self, v: Option<AddressSet>) -> Self {
-        self.builder_disallow = v;
+    /// Set the default builder disallow list url
+    pub fn with_builder_disallow_url(mut self, v: Option<String>) -> Self {
+        self.builder_disallow_url = v;
         self
     }
 
@@ -399,7 +398,7 @@ impl Default for DefaultRpcServerArgs {
             rpc_proof_permits: constants::DEFAULT_PROOF_PERMITS,
             rpc_pending_block: PendingBlockKind::Full,
             rpc_forwarder: None,
-            builder_disallow: None,
+            builder_disallow_url: None,
             rpc_state_cache: RpcStateCacheArgs::default(),
             gas_price_oracle: GasPriceOracleArgs::default(),
             rpc_send_raw_transaction_sync_timeout:
@@ -619,10 +618,10 @@ pub struct RpcServerArgs {
     #[arg(long = "rpc.forwarder", alias = "rpc-forwarder", value_name = "FORWARDER")]
     pub rpc_forwarder: Option<Url>,
 
-    /// Path to file containing disallowed addresses, json-encoded list of strings. Block
-    /// validation API will reject blocks containing transactions from these addresses.
-    #[arg(long = "builder.disallow", value_name = "PATH", value_parser = reth_cli_util::parsers::read_json_from_file::<AddressSet>, default_value = Resettable::from(DefaultRpcServerArgs::get_global().builder_disallow.as_ref().map(|v| format!("{:?}", v).into())))]
-    pub builder_disallow: Option<AddressSet>,
+    /// URL to fetch the disallowed-address list from (json array of address strings). The block
+    /// validation API refreshes from it periodically; if unset, the disallow list is empty.
+    #[arg(long = "builder.disallow-url", value_name = "URL", default_value = Resettable::from(DefaultRpcServerArgs::get_global().builder_disallow_url.as_ref().map(|v| v.clone().into())))]
+    pub builder_disallow_url: Option<String>,
 
     /// State cache configuration.
     #[command(flatten)]
@@ -845,7 +844,7 @@ impl Default for RpcServerArgs {
             rpc_proof_permits,
             rpc_pending_block,
             rpc_forwarder,
-            builder_disallow,
+            builder_disallow_url,
             rpc_state_cache,
             gas_price_oracle,
             rpc_send_raw_transaction_sync_timeout,
@@ -889,7 +888,7 @@ impl Default for RpcServerArgs {
             rpc_proof_permits,
             rpc_pending_block,
             rpc_forwarder,
-            builder_disallow,
+            builder_disallow_url,
             rpc_state_cache,
             gas_price_oracle,
             rpc_send_raw_transaction_sync_timeout,
@@ -1055,7 +1054,7 @@ mod tests {
             rpc_proof_permits: 16,
             rpc_pending_block: PendingBlockKind::Full,
             rpc_forwarder: Some("http://localhost:8545".parse().unwrap()),
-            builder_disallow: None,
+            builder_disallow_url: None,
             rpc_state_cache: RpcStateCacheArgs {
                 max_blocks: 5000,
                 max_receipts: 2000,

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -112,7 +112,8 @@ impl RethRpcServerConfig for RpcServerArgs {
 
     fn flashbots_config(&self) -> ValidationApiConfig {
         ValidationApiConfig {
-            disallow: self.builder_disallow.clone().unwrap_or_default(),
+            // the disallow list is fetched from `builder.disallow-url` during node launch.
+            disallow: Default::default(),
             validation_window: self.rpc_eth_proof_window,
         }
     }

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -71,25 +71,28 @@ where
     ) -> Self {
         let ValidationApiConfig { disallow, validation_window } = config;
 
+        let metrics = ValidationMetrics::default();
+        record_disallow_metrics(&metrics, &disallow);
+
         let inner = Arc::new(ValidationApiInner {
             provider,
             consensus,
             payload_validator,
             evm_config,
-            disallow,
+            disallow: std::sync::RwLock::new(Arc::new(disallow)),
             validation_window,
             cached_state: Default::default(),
             task_spawner,
-            metrics: Default::default(),
+            metrics,
         });
 
-        inner.metrics.disallow_size.set(inner.disallow.len() as f64);
-
-        let disallow_hash = hash_disallow_list(&inner.disallow);
-        let hash_gauge = gauge!("builder_validation_disallow_hash", "hash" => disallow_hash);
-        hash_gauge.set(1.0);
-
         Self { inner }
+    }
+
+    /// Replaces the disallow list (e.g. from a periodic refresh) and re-emits its metrics.
+    pub fn update_disallow(&self, disallow: AddressSet) {
+        record_disallow_metrics(&self.metrics, &disallow);
+        *self.disallow.write().expect("disallow lock poisoned") = Arc::new(disallow);
     }
 
     /// Returns the cached reads for the given head hash.
@@ -135,19 +138,21 @@ where
         self.consensus.validate_header(block.sealed_header())?;
         self.consensus.validate_block_pre_execution(block.sealed_block())?;
 
-        if !self.disallow.is_empty() && transaction_filter == TransactionFilter::OFAC {
-            if self.disallow.contains(&block.beneficiary()) {
+        let disallow = self.disallow.read().expect("disallow lock poisoned").clone();
+
+        if !disallow.is_empty() && transaction_filter == TransactionFilter::OFAC {
+            if disallow.contains(&block.beneficiary()) {
                 return Err(ValidationApiError::Blacklist(block.beneficiary()));
             }
-            if self.disallow.contains(&message.proposer_fee_recipient) {
+            if disallow.contains(&message.proposer_fee_recipient) {
                 return Err(ValidationApiError::Blacklist(message.proposer_fee_recipient));
             }
             for (sender, tx) in block.senders_iter().zip(block.body().transactions()) {
-                if self.disallow.contains(sender) {
+                if disallow.contains(sender) {
                     return Err(ValidationApiError::Blacklist(*sender));
                 }
                 if let Some(to) = tx.to()
-                    && self.disallow.contains(&to)
+                    && disallow.contains(&to)
                 {
                     return Err(ValidationApiError::Blacklist(to));
                 }
@@ -186,11 +191,11 @@ where
 
         let mut accessed_blacklisted = None;
         let output = executor.execute_with_state_closure(&block, |state| {
-            if !self.disallow.is_empty() && transaction_filter == TransactionFilter::OFAC {
+            if !disallow.is_empty() && transaction_filter == TransactionFilter::OFAC {
                 // Check whether the submission interacted with any blacklisted account by scanning
                 // the `State`'s cache that records everything read from database during execution.
                 for account in state.cache.accounts.keys() {
-                    if self.disallow.contains(account) {
+                    if disallow.contains(account) {
                         accessed_blacklisted = Some(*account);
                     }
                 }
@@ -573,8 +578,8 @@ pub struct ValidationApiInner<Provider, E: ConfigureEvm, T: PayloadTypes> {
         Arc<dyn PayloadValidator<T, Block = <E::Primitives as NodePrimitives>::Block>>,
     /// Block executor factory.
     evm_config: E,
-    /// Set of disallowed addresses
-    disallow: AddressSet,
+    /// Disallowed addresses, swappable so a periodic refresh can update them without a restart.
+    disallow: std::sync::RwLock<Arc<AddressSet>>,
     /// The maximum block distance - parent to latest - allowed for validation
     validation_window: u64,
     /// Cached state reads to avoid redundant disk I/O across multiple validation attempts
@@ -602,6 +607,15 @@ fn hash_disallow_list(disallow: &AddressSet) -> String {
     }
 
     format!("{:x}", hasher.finalize())
+}
+
+/// Sets the disallow-list size and hash gauges from the given set.
+fn record_disallow_metrics(metrics: &ValidationMetrics, disallow: &AddressSet) {
+    metrics.disallow_size.set(disallow.len() as f64);
+
+    let disallow_hash = hash_disallow_list(disallow);
+    let hash_gauge = gauge!("builder_validation_disallow_hash", "hash" => disallow_hash);
+    hash_gauge.set(1.0);
 }
 
 impl<Provider, E: ConfigureEvm, T: PayloadTypes> fmt::Debug for ValidationApiInner<Provider, E, T> {


### PR DESCRIPTION
Lets sim nodes pull the OFAC disallow list from the sauron `ofac-api` service instead of a static file, so OFAC updates propagate without a node restart.

- replace `--builder.disallow` (file) with `--builder.disallow-url`; the block-validation `disallow` set is now `RwLock<Arc<AddressSet>>`, hot-swappable via `update_disallow`
- on launch, if a url is set: fetch the list (5 retries) and **panic/exit** if it can't be loaded — a sim node never runs without its list; if no url is set the list is empty and nothing polls
- a background task re-fetches every 5min and swaps in the new set, keeping the last-good list and logging on failure (never clears)
- the per-request `transaction_filter` (none/ofac) enforcement is unchanged; the disallow size/hash metrics are re-emitted on each swap

Pulls from the sauron `ofac-api` service (ultrasoundmoney/sauron#262).
