### PR TITLE
refactor(validation): parking_lot RwLock + skip the lock for non-OFAC requests

### DIFF
--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -138,9 +138,10 @@ where
         self.consensus.validate_header(block.sealed_header())?;
         self.consensus.validate_block_pre_execution(block.sealed_block())?;
 
-        let disallow = self.disallow.read().clone();
+        let disallow =
+            (transaction_filter == TransactionFilter::OFAC).then(|| self.disallow.read().clone());
 
-        if !disallow.is_empty() && transaction_filter == TransactionFilter::OFAC {
+        if let Some(disallow) = &disallow {
             if disallow.contains(&block.beneficiary()) {
                 return Err(ValidationApiError::Blacklist(block.beneficiary()));
             }
@@ -191,7 +192,7 @@ where
 
         let mut accessed_blacklisted = None;
         let output = executor.execute_with_state_closure(&block, |state| {
-            if !disallow.is_empty() && transaction_filter == TransactionFilter::OFAC {
+            if let Some(disallow) = &disallow {
                 // Check whether the submission interacted with any blacklisted account by scanning
                 // the `State`'s cache that records everything read from database during execution.
                 for account in state.cache.accounts.keys() {

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -79,7 +79,7 @@ where
             consensus,
             payload_validator,
             evm_config,
-            disallow: std::sync::RwLock::new(Arc::new(disallow)),
+            disallow: parking_lot::RwLock::new(Arc::new(disallow)),
             validation_window,
             cached_state: Default::default(),
             task_spawner,
@@ -92,7 +92,7 @@ where
     /// Replaces the disallow list (e.g. from a periodic refresh) and re-emits its metrics.
     pub fn update_disallow(&self, disallow: AddressSet) {
         record_disallow_metrics(&self.metrics, &disallow);
-        *self.disallow.write().expect("disallow lock poisoned") = Arc::new(disallow);
+        *self.disallow.write() = Arc::new(disallow);
     }
 
     /// Returns the cached reads for the given head hash.
@@ -138,7 +138,7 @@ where
         self.consensus.validate_header(block.sealed_header())?;
         self.consensus.validate_block_pre_execution(block.sealed_block())?;
 
-        let disallow = self.disallow.read().expect("disallow lock poisoned").clone();
+        let disallow = self.disallow.read().clone();
 
         if !disallow.is_empty() && transaction_filter == TransactionFilter::OFAC {
             if disallow.contains(&block.beneficiary()) {
@@ -579,7 +579,7 @@ pub struct ValidationApiInner<Provider, E: ConfigureEvm, T: PayloadTypes> {
     /// Block executor factory.
     evm_config: E,
     /// Disallowed addresses, swappable so a periodic refresh can update them without a restart.
-    disallow: std::sync::RwLock<Arc<AddressSet>>,
+    disallow: parking_lot::RwLock<Arc<AddressSet>>,
     /// The maximum block distance - parent to latest - allowed for validation
     validation_window: u64,
     /// Cached state reads to avoid redundant disk I/O across multiple validation attempts


### PR DESCRIPTION
Follow-up to #7, addressing the lock review feedback.

- Use `parking_lot::RwLock` for the disallow list — non-poisoning, drops the `.expect()`s on every read/write.
- Only acquire the disallow lock for OFAC-filtered requests; non-OFAC submissions never consult the list.

(The disallow-list *staleness* handling from the review is deferred: it needs to be enforced at the relay/auction layer rather than as a per-block sim error, so a stale list can't look like a builder fault and trigger demotions.)
