### PR TITLE
ci(docker-git): skip discarded arch compile for single-arch builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,13 +246,17 @@ docker-build-push-nightly: ## Build and push cross-arch Docker image tagged with
 
 # Create a cross-arch Docker image with the given tags and push it
 define docker_build_push
-	$(MAKE) build-x86_64-unknown-linux-gnu
-	mkdir -p $(BIN_DIR)/amd64
-	cp $(CARGO_TARGET_DIR)/x86_64-unknown-linux-gnu/$(PROFILE)/reth $(BIN_DIR)/amd64/reth
+	$(if $(findstring amd64,$(BUILD_PLATFORMS)), \
+		$(MAKE) build-x86_64-unknown-linux-gnu && \
+		mkdir -p $(BIN_DIR)/amd64 && \
+		cp $(CARGO_TARGET_DIR)/x86_64-unknown-linux-gnu/$(PROFILE)/reth $(BIN_DIR)/amd64/reth, \
+		@echo "skipping amd64 build, not in BUILD_PLATFORMS=$(BUILD_PLATFORMS)")
 
-	$(MAKE) build-aarch64-unknown-linux-gnu
-	mkdir -p $(BIN_DIR)/arm64
-	cp $(CARGO_TARGET_DIR)/aarch64-unknown-linux-gnu/$(PROFILE)/reth $(BIN_DIR)/arm64/reth
+	$(if $(findstring arm64,$(BUILD_PLATFORMS)), \
+		$(MAKE) build-aarch64-unknown-linux-gnu && \
+		mkdir -p $(BIN_DIR)/arm64 && \
+		cp $(CARGO_TARGET_DIR)/aarch64-unknown-linux-gnu/$(PROFILE)/reth $(BIN_DIR)/arm64/reth, \
+		@echo "skipping arm64 build, not in BUILD_PLATFORMS=$(BUILD_PLATFORMS)")
 
 	docker buildx build --file ./Dockerfile . \
 		--platform $(BUILD_PLATFORMS) \


### PR DESCRIPTION
`docker-git` publishes `linux/amd64` only (`BUILD_PLATFORMS=linux/amd64`), but `docker_build_push` unconditionally cross-compiled the aarch64 binary as well — a full maxperf compile that is then discarded, roughly doubling wall time (last run: 1h31m).

This gates each arch compile on `BUILD_PLATFORMS` so single-arch builds skip the unused cross-compile. Multi-arch release targets (default `BUILD_PLATFORMS=linux/amd64,linux/arm64`) still build and publish both.

Verified by expansion test: with `BUILD_PLATFORMS=linux/amd64` only x86_64 is compiled; with the default both arches are compiled and published.